### PR TITLE
Changed default evalScripts prop to match documentation.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default class ReactSVG extends React.Component {
   static defaultProps = {
     callback: () => {},
     className: null,
-    evalScripts: 'once',
+    evalScripts: 'never',
     style: {},
     wrapperClassName: null
   }


### PR DESCRIPTION
# Motivation
The documentation mentions that the default value for evalScripts is `never`. The code actually sets the value to `once`. The evalScripts prop allows scripts to run, this could lead to XSS exploits.