### PR TITLE
Props interface improvement/fix

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,8 +12,8 @@ import shallowDiffers from './shallow-differs'
 type WrapperType = HTMLSpanElement | HTMLDivElement
 
 interface Props {
-  afterInjection: Errback
-  beforeInjection: BeforeEach
+  afterInjection?: Errback
+  beforeInjection?: BeforeEach
   evalScripts?: EvalScripts
   fallback?: React.ReactType
   loading?: React.ReactType


### PR DESCRIPTION
afterInjection and beforeInjection are optional, but Props interface did not reflect that. Made them optional, default values were already defined as well as documentation stating that they should be optional.