### PR TITLE
move @types/prop-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@tanem/svg-injector": "^10.0.0",
-    "prop-types": "^15.7.2",
-    "@types/prop-types": "15.7.3"
+    "@types/prop-types": "15.7.3",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/core": "7.13.14",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@tanem/svg-injector": "^10.0.0",
-    "@types/prop-types": "15.7.3",
+    "@types/prop-types": "^15.7.3",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@tanem/svg-injector": "^10.0.0",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "@types/prop-types": "15.7.3"
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
@@ -66,7 +67,6 @@
     "@types/faker": "5.5.0",
     "@types/jest": "26.0.22",
     "@types/jsdom": "16.2.10",
-    "@types/prop-types": "15.7.3",
     "@types/react": "17.0.3",
     "@types/react-dom": "17.0.3",
     "@typescript-eslint/eslint-plugin": "4.21.0",


### PR DESCRIPTION
This PR will move @types/prop-types from devDependencies to dependencies. This will add compatibility with yarn 2 and other strictly scoped package managers.