### PR TITLE
feat: add "use client" to published bundles

### DIFF
--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -2,6 +2,11 @@
 
 This project was bootstrapped with [Next.js](https://nextjs.org/).
 
+`ReactSVG` is published with a `"use client"` directive, so it can be imported
+directly into a Server Component - see `app/page.js`. Props that take functions
+(`afterInjection`, `beforeInjection`, `fallback`, `loading`) can't cross the
+server/client boundary, so pass those from your own Client Component.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/examples/ssr/app/page.js
+++ b/examples/ssr/app/page.js
@@ -1,8 +1,5 @@
-'use client'
-
-import ClipLoader from 'react-spinners/ClipLoader'
 import { ReactSVG } from 'react-svg'
 
 export default function Home() {
-  return <ReactSVG loading={() => <ClipLoader />} src="svg.svg" />
+  return <ReactSVG src="svg.svg" />
 }

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -16,7 +16,6 @@
     "next": "15.5.22",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-spinners": "0.17.0",
     "react-svg": "latest"
   },
   "license": "MIT"

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use client'
 'use strict'
 
 if (process.env.NODE_ENV === 'production') {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,6 +14,11 @@ const UMD_PROD = 'UMD_PROD'
 
 const input = './compiled/index.js'
 
+// Rollup strips file-level directives while bundling, so `"use client"` has to
+// be re-added to the output. UMD bundles are script-tag targets and have no
+// React Server Components boundary to mark, so they are left alone.
+const banner = `'use client';`
+
 const getExternal = (bundleType) => {
   const peerDependencies = Object.keys(pkg.peerDependencies)
   const dependencies = Object.keys(pkg.dependencies)
@@ -90,6 +95,10 @@ const getPlugins = (bundleType) => [
   isProduction(bundleType) &&
     terser({
       compress: {
+        // Terser treats `'use client'` as a non-standard directive and drops
+        // it by default, which would strip the banner from the minified
+        // bundles.
+        directives: false,
         keep_infinity: true,
         pure_getters: true,
       },
@@ -103,6 +112,7 @@ const getCjsConfig = (bundleType) => ({
   external: getExternal(bundleType),
   input,
   output: {
+    banner,
     file: `dist/react-svg.cjs.${
       isProduction(bundleType) ? 'production' : 'development'
     }.js`,
@@ -116,6 +126,7 @@ const getEsConfig = () => ({
   external: getExternal(ES),
   input,
   output: {
+    banner,
     file: pkg.module,
     format: 'es',
     sourcemap: true,

--- a/test/bundles.spec.ts
+++ b/test/bundles.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+// UMD bundles are script-tag targets, so they have no React Server Components
+// boundary to mark.
+const entryPoints = [
+  'index.js',
+  'react-svg.cjs.development.js',
+  'react-svg.cjs.production.js',
+  'react-svg.esm.js',
+]
+
+describe.each(entryPoints)('%s', (entryPoint) => {
+  it('should start with the "use client" directive', () => {
+    const contents = fs.readFileSync(
+      path.join(process.cwd(), 'dist', entryPoint),
+      'utf8',
+    )
+    expect(contents).toMatch(/^["']use client["']/)
+  })
+})


### PR DESCRIPTION
Closes #2888.

`ReactSVG` fetches and injects in lifecycle code, so it is client-only. Publishing the `"use client"` directive means Next.js App Router users no longer need to hand-wrap the component in their own client boundary.

## Changes

- `output.banner` on the CJS and ES Rollup configs. Rollup strips file-level directives while bundling, so a source-file directive would be lost.
- `compress.directives: false` for Terser. It classifies `"use client"` as a non-standard directive and was silently stripping the banner from `react-svg.cjs.production.js`.
- `dist/index.js` (the CJS entry shim) carries the directive above `'use strict'`.
- UMD bundles are unchanged - they are script-tag targets with no server components boundary to mark.
- `test/bundles.spec.ts` asserts the directive on all four published entry points, so a future Rollup or Terser bump can't drop it unnoticed.
- The ssr example is now a Server Component importing `ReactSVG` directly, with no consumer-side wrapper. Its `loading={() => <ClipLoader />}` prop was removed because function props can't cross the server/client boundary; `react-spinners` is dropped and the example README notes the constraint.

## Verification

- `npm test` passes, including the React 16.0 - 19.1 matrix.
- `next build` of `examples/ssr` against the local `dist` succeeds. Stripping the directive back out of the installed `dist` fails that build with `TypeError: Cannot read properties of undefined (reading 'prototype')` during page-data collection, confirming the directive is what makes it work.
- `vite build` of `examples/basic-usage` against the local `dist` is clean, no directive warnings.

## Follow-up

Wiring `next build` of the ssr example into CI as a dedicated job is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)