### PR TITLE
Fix the CodeSandbox setup failure in the examples

### DIFF
--- a/examples/accessibility/.codesandbox/tasks.json
+++ b/examples/accessibility/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/api-usage/.codesandbox/tasks.json
+++ b/examples/api-usage/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/basic-usage/.codesandbox/tasks.json
+++ b/examples/basic-usage/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/before-injection/.codesandbox/tasks.json
+++ b/examples/before-injection/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/css-animation/.codesandbox/tasks.json
+++ b/examples/css-animation/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/css-in-js/.codesandbox/tasks.json
+++ b/examples/css-in-js/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/data-url/.codesandbox/tasks.json
+++ b/examples/data-url/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/external-stylesheet/.codesandbox/tasks.json
+++ b/examples/external-stylesheet/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/fallbacks/.codesandbox/tasks.json
+++ b/examples/fallbacks/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/iframe/.codesandbox/tasks.json
+++ b/examples/iframe/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/loading/.codesandbox/tasks.json
+++ b/examples/loading/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/no-extension/.codesandbox/tasks.json
+++ b/examples/no-extension/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/sprite-usage/.codesandbox/tasks.json
+++ b/examples/sprite-usage/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/ssr/.codesandbox/tasks.json
+++ b/examples/ssr/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/styled-components/.codesandbox/tasks.json
+++ b/examples/styled-components/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/svg-wrapper/.codesandbox/tasks.json
+++ b/examples/svg-wrapper/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }

--- a/examples/typescript/.codesandbox/tasks.json
+++ b/examples/typescript/.codesandbox/tasks.json
@@ -1,10 +1,6 @@
 {
   "setupTasks": [
     {
-      "name": "Update pnpm",
-      "command": "npm i -g pnpm@latest"
-    },
-    {
       "name": "Install Dependencies",
       "command": "pnpm install"
     }


### PR DESCRIPTION
Every example ran `npm i -g pnpm@latest` as a CodeSandbox setup task before installing. That now resolves to pnpm 11, which requires Node 22.13 and loads `node:sqlite`. The `ghcr.io/codesandbox/devcontainers/typescript-node:latest` image still ships Node 20.12, so the task threw `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite` and setup died before `pnpm install` ran.

The upstream [react-vite](https://github.com/codesandbox/sandbox-templates/tree/main/react-vite) and [nextjs](https://github.com/codesandbox/sandbox-templates/tree/main/nextjs) templates no longer have the task and use the pnpm preinstalled in the image. This removes it from all 17 examples to match.

Pinning to `pnpm@10` would also unblock it, but it diverges from the templates and breaks again once CodeSandbox moves the image to Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)