### PR TITLE
Correct what AGENTS.md says npm test runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,11 @@ the injection flow.
 
 ## Build & test
 
-`npm run test:src` is the development loop. `npm test` is the full gate.
-`npm run test:react` runs the React matrix and is slow enough to be
-pre-release only. `npm run size`, `npm run test:dist` and the `package:*`
-checks read `dist/`, so they need a current `npm run build`. A new spec that
-reads `dist/` goes in `config/jest/dist-tests.js`, which keeps it out of
-`test:src`.
+`npm run test:src` is the development loop. `npm test` is the full gate: its
+`test:*` glob includes `test:react`, which installs and runs every version in
+the React matrix, so expect it to take minutes. `npm run size`,
+`npm run test:dist` and the `package:*` checks read `dist/`, so they need a
+current `npm run build`.
 
 Give each test its own `faker.seed()` and a `faker.string.uuid()` SVG URL, or
 svg-injector's cache leaks state between tests. Injection is async: assert


### PR DESCRIPTION
AGENTS.md said `npm run test:react` was slow enough to be pre-release only, separate from `npm test`. It isn't: `"test": "run-s check:* lint build size test:*"`, and `npm-run-all2` expands that glob to `[test:cjs, test:dist, test:es, test:src, test:react]`. `scripts/test-react.ts` has no CI guard, so `ci.yml` installs all seven React versions on every push and pull request. Reworded to describe what actually happens.

Also drops the sentence about `config/jest/dist-tests.js`. The comment at the top of that file already says the same thing, and the AGENTS.md preamble says a constraint that can live next to the thing it constrains belongs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)