### PR TITLE
Update tanem-scripts to 8.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "react-svg",
-      "version": "17.2.5",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@tanem/svg-injector": "^11.3.1"
@@ -43,7 +43,7 @@
         "shelljs": "0.10.0",
         "shx": "0.4.0",
         "size-limit": "13.0.2",
-        "tanem-scripts": "8.0.4",
+        "tanem-scripts": "8.0.7",
         "ts-jest": "29.4.6",
         "ts-node": "10.9.2",
         "tsdown": "0.22.14",
@@ -10967,9 +10967,9 @@
       }
     },
     "node_modules/tanem-scripts": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/tanem-scripts/-/tanem-scripts-8.0.4.tgz",
-      "integrity": "sha512-8f3qA7SBzNEHdEMfcqka8EAMQBKkSE+xJmsycj8nzUsglDTJrgtwMIrZOwcoso0hYm1NtmPoQWCUvBTlJmtkDw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/tanem-scripts/-/tanem-scripts-8.0.7.tgz",
+      "integrity": "sha512-qifMQdYX/ZH0tWR2CwT68Osdov8oCZzzORd+DVpIH9B9Tw0HsZmVAJHIUKTn3JonWQDj3up9LEkXv1W85C7mvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "shelljs": "0.10.0",
     "shx": "0.4.0",
     "size-limit": "13.0.2",
-    "tanem-scripts": "8.0.4",
+    "tanem-scripts": "8.0.7",
     "ts-jest": "29.4.6",
     "ts-node": "10.9.2",
     "tsdown": "0.22.14",


### PR DESCRIPTION
The weekly release workflow fails on any Monday where no PRs have merged since the last tag. `tanem-scripts` treated that normal outcome as an error, exiting 1 with a stack trace. Four scheduled runs failed this way between 2026-07-06 and 2026-07-27.

`tanem-scripts` 8.0.7 returns a sentinel instead of throwing: the CLI prints `Nothing to release` and exits 0, while still failing for genuine validation errors such as unlabelled or multi-labelled PRs.

Verified locally: the release CLI exits 0 on the nothing-to-release path with the data layer stubbed to that condition, and `npm test` passes across React 16.8 through 19.1.

The same bump landed in svg-injector on its `v12` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)