### PR TITLE
Polyfill TextDecoder for jsdom

### DIFF
--- a/config/jest/setupJest.ts
+++ b/config/jest/setupJest.ts
@@ -2,6 +2,13 @@
 // svg-injector uses CSS.escape in extractSymbol for sprite support.
 import 'css.escape'
 
+// Polyfill TextDecoder for the same reason: jsdom does not expose it on
+// window. svg-injector uses it in parseDataUrl to decode base64 data URLs as
+// UTF-8, so without it a base64 data URL fails to parse.
+import { TextDecoder } from 'node:util'
+
+globalThis.TextDecoder ??= TextDecoder as typeof globalThis.TextDecoder
+
 const originalError = console.error
 
 beforeAll(() => {


### PR DESCRIPTION
svg-injector v12 decodes base64 data URLs as UTF-8 with `TextDecoder`, which jsdom does not expose on `window`. v11 shipped a fallback for that case; v12 drops it, on the grounds that the library targets browsers and this repo already polyfills `CSS.escape` for exactly the same reason.

Verified against a tarball built from svg-injector's `v12` branch: without this change one test fails, `should inject from a base64-encoded data URL`. With it, the full matrix passes across React 16.8 through 19.1.

Landing it ahead of the `^12.0.0` bump keeps the tarball checks that run against svg-injector's v12 branch green in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)