### PR TITLE
Update @tanem/svg-injector to v12

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,7 @@ build
 coverage
 dist
 package.json
+# Git-excluded scratch area holding manual-check harnesses, which are written
+# against the browser rather than this project's config. Absent for anyone
+# else, so this entry is inert for them and keeps `npm test` passing here.
+roadmap

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ current `npm run build`.
 
 Give each test its own `faker.seed()` and a `faker.string.uuid()` SVG URL, or
 svg-injector's cache leaks state between tests. Injection is async: assert
-through `await waitFor(...)`.
+through `await waitFor(...)`. The warm-cache loading test is the one deliberate
+exception: it needs the cache to hit, so it uses a fixed URL no other test
+touches.
 
 Raising a `size-limit` budget in `package.json` is a decision, not a fix. Find
 what grew first, and say why in the commit message.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,26 @@
 
 Details relating to major changes that aren't presently in `CHANGELOG.md`, due to limitations with how that file is being generated.
 
+## v19.0.0
+
+Nothing in this package's own API changed. Every entry below comes from [`@tanem/svg-injector`](https://github.com/tanem/svg-injector) moving to v12 (see its [migration notes](https://github.com/tanem/svg-injector/blob/master/MIGRATION.md#v1200) for the packaging changes, which only affect you if you also depend on it directly).
+
+**Changed**
+
+- Test suites running under jsdom need a `TextDecoder` polyfill. svg-injector uses `TextDecoder` to decode base64 `data:image/svg+xml` URLs as UTF-8, and jsdom does not expose it, so rendering `<ReactSVG src="data:image/svg+xml;base64,…" />` throws `ReferenceError: TextDecoder is not defined`. Add it to your Jest setup file:
+
+  ```ts
+  import { TextDecoder } from 'node:util'
+
+  globalThis.TextDecoder ??= TextDecoder as typeof globalThis.TextDecoder
+  ```
+
+  jsdom also lacks `CSS.escape`, which svg-injector uses to look up a sprite symbol. If you render an `src` with a fragment identifier, `import 'css.escape'` in the same file.
+
+- A `src` whose `.svg` appears outside the URL pathname now needs a valid `Content-Type`. svg-injector skips the `Content-Type` response header check for URLs ending in `.svg`, and it used to match that against the whole URL. It now matches against the end of the pathname, so `src="/render?file=logo.svg"` served without a valid `Content-Type` reports an error through `onError` where it previously injected. Serve `image/svg+xml` (or `text/plain`), or move the extension into the pathname.
+
+- The `loading` element now enters the DOM when the same `src` is mounted a second time. svg-injector v12 defers its callbacks, so `loading` renders and is then removed, where v11 called back synchronously for a cached `src` and React collapsed both state updates into a single render that never showed it. Nothing paints differently: a paint-level A/B measured 1 painted frame in 95 deferred mounts against 2 in 95 synchronous ones, which is React's own scheduling either way.
+
 ## v18.0.0
 
 **Added**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,16 @@ import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   {
-    ignores: ['**/build/', '**/coverage/', '**/dist/', '**/node_modules/'],
+    ignores: [
+      '**/build/',
+      '**/coverage/',
+      '**/dist/',
+      '**/node_modules/',
+      // Git-excluded scratch area, outside every tsconfig and written for the
+      // browser and node rather than this project's globals. Absent for
+      // anyone else.
+      'roadmap/',
+    ],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
-        "@tanem/svg-injector": "^11.3.1"
+        "@tanem/svg-injector": "^12.0.0"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.5",
@@ -636,6 +636,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3038,15 +3039,10 @@
       }
     },
     "node_modules/@tanem/svg-injector": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/@tanem/svg-injector/-/svg-injector-11.3.2.tgz",
-      "integrity": "sha512-ueEvDtrnWHK9FpPWcAC5J4hNcibHjfJCwURhSdt72xOa2fWgndNR9ro7nzb6SwAeB0dioMvxsv7/kKdm4znytw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "content-type": "^1.0.5",
-        "tslib": "^2.8.1"
-      }
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@tanem/svg-injector/-/svg-injector-12.0.0.tgz",
+      "integrity": "sha512-L8jGOTd6wkgST9EjFO2jnhyx4ZkIRvxNdUsUQU4DEC/Uxl0f5Ftiovg0cO05ShTXKBGgBEd8QtFcLqnlsmFMYA==",
+      "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -5491,15 +5487,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -11414,7 +11401,9 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@tanem/svg-injector": "^11.3.1"
+    "@tanem/svg-injector": "^12.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",

--- a/test/browser.spec.tsx
+++ b/test/browser.spec.tsx
@@ -234,6 +234,44 @@ describe('while running in a browser environment', () => {
     )
   })
 
+  // Deliberately breaks the fixed-`src` convention noted at the top of this
+  // file: warming SVGInjector's cache is the point. From v12 it defers the
+  // cache-hit callback, so `setIsLoading(false)` lands in a later task than
+  // the mount and the loader is committed to the DOM. Under v11 both updates
+  // shared one task, React collapsed them, and the loader never appeared for
+  // a cached `src`.
+  it('should render the specified loader for a cached src', async () => {
+    const loading = () => <span>loading</span>
+    const src = 'http://localhost/warm-cache.svg'
+
+    nock('http://localhost')
+      .get('/warm-cache.svg')
+      .reply(200, source, { 'Content-Type': 'image/svg+xml' })
+
+    const first = render(<ReactSVG loading={loading} src={src} />)
+
+    await waitFor(() =>
+      expect(first.container.querySelectorAll('.injected-svg')).toHaveLength(1),
+    )
+
+    first.unmount()
+
+    // No interceptor is left in place, so a second request fails to connect
+    // rather than quietly succeeding. The injection below can only come from
+    // the cache.
+    nock.cleanAll()
+
+    const second = render(<ReactSVG loading={loading} src={src} />)
+
+    expect(second.getByText('loading')).toBeTruthy()
+
+    await waitFor(() =>
+      expect(second.container.querySelectorAll('.injected-svg')).toHaveLength(
+        1,
+      ),
+    )
+  })
+
   it('allows rendering of span wrappers', async () => {
     faker.seed(132)
     const uuid = faker.string.uuid()


### PR DESCRIPTION
Nothing in this package's own API changes, and `src/` is untouched. The major is for what consumers experience when a caret range picks the bump up.

## Why a major

1. **Consumers' jsdom suites break.** The decisive one. svg-injector v12 uses `TextDecoder` to decode base64 `data:image/svg+xml` URLs, and jsdom does not expose it, so a consumer whose Jest suite renders `<ReactSVG src="data:image/svg+xml;base64,…" />` gets a `ReferenceError`. A minor would deliver that silently, on install.
2. **A working `src` can start failing.** v12 narrows the `.svg` content-type bypass to the URL pathname, so a `src` like `/render?file=logo.svg` served without a valid `Content-Type` now reports through `onError` where v11 injected it.
3. **`loading` now enters the DOM for a cached `src`.** v12 defers its callbacks, so the two state updates land in different tasks instead of being collapsed into one render.

`MIGRATION.md` covers all three, with the polyfill snippet, the shape of `src` that changes, and a pointer to svg-injector's own migration notes rather than restating them.

## On the `loading` change

There is no visible flash: a paint-level A/B in svg-injector measured 1 painted frame in 95 deferred cached mounts against 2 in 95 synchronous ones, which is React's own scheduling either way.

Whether the briefly-mounted element announces to a screen reader was measured rather than assumed, since assistive technology observes the DOM and not the screen. In Safari on macOS 26.5 under VoiceOver: **no announcement**. VoiceOver announces a live region whose content changes and ignores one that arrives already populated, which is how React mounts a `loading` component — so lifetime is not the variable, and a `role="status"` element left mounted for 2.5s was equally silent. This was verified with a control that announces (an existing region whose text changes) and with the same insertion performed outside React entirely. Untested on NVDA and JAWS; the constraint is standard ARIA rather than a VoiceOver quirk.

## Verification

- `npm test` green: types, lint, build, size, and all seven `test:react` versions (16.8, 16.14, 17.0, 18.0, 18.3, 19.0, 19.1).
- 22 snapshots unchanged, no `src/` change.
- New test pins the warm-cache `loading` behaviour, which the suite could not previously reach: every existing test uses a fresh uuid so svg-injector's cache never warms. It was confirmed failing against v11 first, for the right reason.
- Confirmed in a real browser as well as jsdom: 8 cached remounts, median loading-element lifetime 2.0ms, 0 requests served.

The lint/format ignore commit is housekeeping: both walked the git-excluded `roadmap/` directory, which now holds a browser-targeted harness, so `npm test` failed before reaching anything real.
