### PR TITLE
Describe the commit messages this repo actually writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,10 @@ constrains belongs there, not here.
 - NZ English everywhere ("colour", "behaviour", "initialise").
 - Match a document's length to what it needs. Cover the substance, then
   stop: no filler sections, restated summaries or boilerplate.
-- Single-line commit messages, `git log --oneline` style. Add a body only to
-  explain why, and only for behaviour or type changes.
+- Commit subjects are one capitalised line, `git log --oneline` style. Add a
+  body whenever the change had a reason the diff does not show: what it fixes,
+  what it rules out, what constraint forced the shape it has. Mechanical
+  changes need none.
 - No conventional-commit prefixes (`feat:`, `fix:`, `chore(deps):`) in commit
   subjects or PR titles. Write a plain capitalised sentence. Nothing reads the
   prefix: the version bump comes from the PR label, and renovate is set to


### PR DESCRIPTION
The Writing section said single-line commit messages, with a body only for behaviour or type changes. Neither half has described this repo for a while: the `loadingDelay` work ran to 17-, 24- and 28-line bodies, the screen-reader harness to 16, and none of those is a type change.

The replacement asks for a body whenever the change had a reason the diff does not show, and says mechanical changes need none.

Wording is shared with `@tanem/svg-injector`, which carried the identical sentence against the identical practice — [tanem/svg-injector#1576](https://github.com/tanem/svg-injector/pull/1576) fixes it there — so the two Writing sections stay diffable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)