### PR TITLE
Title the catch-all release-notes category for what it holds

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,10 @@ changelog:
     - title: 🚀 Enhancements
       labels:
         - enhancement
-    - title: 🛠 Everything Else
+    # The catch-all, and so the patch category: under the label convention
+    # everything reaching it is a patch. Titled for what it holds rather than
+    # the bump it causes, so that it still reads on the many weeks where it is
+    # the only section there is.
+    - title: 🛠 Fixes & Maintenance
       labels:
         - '*'


### PR DESCRIPTION
Most weeks release nothing but patches, so "Everything Else" ends up the only heading in the generated notes — and a heading that defines itself by contrast reads as a mistake when there is nothing to contrast it with.

"Fixes & Maintenance" reads alone and reads as the third of three. It is also the more honest name: under the label convention every PR that falls through to the catch-all is a patch, so this was never a junk drawer for uncategorised work.

Showing the heading only when the other two are populated is not expressible here. GitHub evaluates this file identically every release, so a conditional heading would mean generating the notes by hand rather than letting GitHub write them. Dropping the catch-all instead is worse: without `*` GitHub omits the unmatched pull requests from the notes entirely, which on a patch-only week is all of them.

Cosmetic and forward-only — already-published releases keep the heading they were generated with.